### PR TITLE
Modify spec.json to set 6.0.0-SNAPSHOT as the upper bound

### DIFF
--- a/packages/database-plugin-db2-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-db2-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "DB2 Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/database-plugin-mssql-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-mssql-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "SQL Server Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/database-plugin-mysql-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-mysql-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "MySQL Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/database-plugin-netezza-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-netezza-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Netezza Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/database-plugin-oracle-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-oracle-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Oracle Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/database-plugin-postrgesql-plugin/1.0.0/spec.json
+++ b/packages/database-plugin-postrgesql-plugin/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "PostgreSQL Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1553089918,
   "categories": [
     "EDW Offloading",

--- a/packages/directive-image-exif/1.0.0/spec.json
+++ b/packages/directive-image-exif/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "EXIF Meta Extractor",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.1,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.1,6.0.0-SNAPSHOT)",
   "created": 1509903767,
   "categories": [
     "Directives"

--- a/packages/directive-xml/1.0.0/spec.json
+++ b/packages/directive-xml/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "XML Transformations",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.1,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.1,6.0.0-SNAPSHOT)",
   "created": 1509903767,
   "categories": [
     "Directives"

--- a/packages/example-log-analysis/4.2.0/spec.json
+++ b/packages/example-log-analysis/4.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Log Analysis Example",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496865655,
   "categories": [
     "example"

--- a/packages/example-spark-kmeans/4.2.0/spec.json
+++ b/packages/example-spark-kmeans/4.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Spark KMeans Example",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496865680,
   "categories": [
     "example"

--- a/packages/example-spark-pagerank/4.2.0/spec.json
+++ b/packages/example-spark-pagerank/4.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Spark PageRank Example",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496865711,
   "categories": [
     "example"

--- a/packages/example-wikipedia-pipeline/4.2.0/spec.json
+++ b/packages/example-wikipedia-pipeline/4.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Wikipedia Pipeline Example",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496865775,
   "categories": [
     "example"

--- a/packages/example-wordcount/4.2.0/spec.json
+++ b/packages/example-wordcount/4.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Word Count Example",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496865815,
   "categories": [
     "example"

--- a/packages/hydrator-pipeline-csv-parser/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-csv-parser/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "CSV Parsing",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496359079,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-import-excel/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-import-excel/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Import Data from Excel",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1496359350,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-import-mysql/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-import-mysql/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Import Data From MySQL",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496359411,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-javascript-transform/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-javascript-transform/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "JavaScript Transform",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496359604,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-join-data/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-join-data/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Join Data Sources",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496359690,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-kafka-ingest/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-kafka-ingest/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Kafka Ingest",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496359800,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-log-data-processing/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-log-data-processing/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Log Data Analytics",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496359885,
   "categories": [
     "AWS",
@@ -20,7 +20,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-masking-sensitive-data/1.3.0/spec.json
+++ b/packages/hydrator-pipeline-masking-sensitive-data/1.3.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Masking Sensitive Data",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.0.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.0.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1531777798,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-mysql-to-bigquery/1.0.0/spec.json
+++ b/packages/hydrator-pipeline-mysql-to-bigquery/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Transfer Data From MySQL to Google BigQuery",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[5.0.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.0.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1532801520,
   "categories": [
     "pipeline",
@@ -68,7 +68,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[5.0.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[5.0.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-projection-pipeline/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-projection-pipeline/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Projection Pipeline",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496360089,
   "categories": [
     "pipeline"
@@ -53,7 +53,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-pipeline-xml-parsing/1.2.0/spec.json
+++ b/packages/hydrator-pipeline-xml-parsing/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "XML Parsing",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496360218,
   "categories": [
     "pipeline"
@@ -19,7 +19,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/hydrator-plugin-add-field-transform/2.0.0/spec.json
+++ b/packages/hydrator-plugin-add-field-transform/2.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1503338265,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-azure-blob-store-plugin/1.1.0/spec.json
+++ b/packages/hydrator-plugin-azure-blob-store-plugin/1.1.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Microsoft Azure Blob Store Source Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT]",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1503371365,
   "categories": [
     "Azure",

--- a/packages/hydrator-plugin-azure-datalake-store-plugin/1.5.0/spec.json
+++ b/packages/hydrator-plugin-azure-datalake-store-plugin/1.5.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Microsoft Azure Data Lake Source/Sink Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1516915331 ,
   "categories": [
     "Azure",

--- a/packages/hydrator-plugin-azure-event-hub/1.1.0-2.10/spec.json
+++ b/packages/hydrator-plugin-azure-event-hub/1.1.0-2.10/spec.json
@@ -4,7 +4,7 @@
   "label": "Microsoft Azure Event Hub Realtime Source(Spark1)",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1503375288,
   "categories": [
     "Azure",

--- a/packages/hydrator-plugin-azure-event-hub/1.1.0-2.11/spec.json
+++ b/packages/hydrator-plugin-azure-event-hub/1.1.0-2.11/spec.json
@@ -4,7 +4,7 @@
   "label": "Microsoft Azure Event Hub Realtime Source(Spark2)",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1503375288,
   "categories": [
     "Azure",

--- a/packages/hydrator-plugin-azure-face-transform/1.0.0/spec.json
+++ b/packages/hydrator-plugin-azure-face-transform/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Microsoft Azure Face Transform",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1488956298,
   "categories": [
     "Azure",

--- a/packages/hydrator-plugin-cdc-plugins/1.0.0/spec.json
+++ b/packages/hydrator-plugin-cdc-plugins/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Change Data Capture(CDC)",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1490739442,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-date-transform/1.1.1/spec.json
+++ b/packages/hydrator-plugin-date-transform/1.1.1/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1496340545,
   "categories": [ "hydrator-plugin", "EDW Offloading" ],
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-dynamic-spark/2.1.1/spec.json
+++ b/packages/hydrator-plugin-dynamic-spark/2.1.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Dynamic Spark Plugin",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.1-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.1-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1534349943,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-elasticsearch/1.8.0/spec.json
+++ b/packages/hydrator-plugin-elasticsearch/1.8.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Elasticsearch Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496340763,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-fast-filter-transform/1.6.1/spec.json
+++ b/packages/hydrator-plugin-fast-filter-transform/1.6.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Fast Filter Transform",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496341052,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-ftp-plugins/1.1.1/spec.json
+++ b/packages/hydrator-plugin-ftp-plugins/1.1.1/spec.json
@@ -4,7 +4,7 @@
   "label": "FTP Copy",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "created": 1490739442,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-gcp-plugins/0.9.2/spec.json
+++ b/packages/hydrator-plugin-gcp-plugins/0.9.2/spec.json
@@ -4,7 +4,7 @@
   "label": "Google Cloud Platform plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1518205410,
   "categories": [
     "gcp",

--- a/packages/hydrator-plugin-hive/1.7.2-1.1.0/spec.json
+++ b/packages/hydrator-plugin-hive/1.7.2-1.1.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Hive Import/Export Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1512507958,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-http-sink/1.0.1/spec.json
+++ b/packages/hydrator-plugin-http-sink/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "HTTP Sink",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496341495,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-httptohdfs-action/1.0.1/spec.json
+++ b/packages/hydrator-plugin-httptohdfs-action/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "HTTP to HDFS Action",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496341573,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-kafka-plugins/1.8.2-0.10.2.0/spec.json
+++ b/packages/hydrator-plugin-kafka-plugins/1.8.2-0.10.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Kafka Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1529095811,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-kafka-plugins/1.8.2-0.8.2.2/spec.json
+++ b/packages/hydrator-plugin-kafka-plugins/1.8.2-0.8.2.2/spec.json
@@ -4,7 +4,7 @@
   "label": "Kafka Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1529095811,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-kinesis-batchsink/1.6.1/spec.json
+++ b/packages/hydrator-plugin-kinesis-batchsink/1.6.1/spec.json
@@ -9,7 +9,7 @@
     "AWS",
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-loadtosnowflake-action/1.0.1/spec.json
+++ b/packages/hydrator-plugin-loadtosnowflake-action/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Load to Snowflake Action",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496342123,
   "categories": [
     "AWS",

--- a/packages/hydrator-plugin-mainframe-reader/1.6.2/spec.json
+++ b/packages/hydrator-plugin-mainframe-reader/1.6.2/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1496342277,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-oracle-export-action/1.6.1/spec.json
+++ b/packages/hydrator-plugin-oracle-export-action/1.6.1/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1496343246,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-orientdb/1.0.0/spec.json
+++ b/packages/hydrator-plugin-orientdb/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "OrientDB Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1488956298,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-pdf-extractor-transform/1.0.1/spec.json
+++ b/packages/hydrator-plugin-pdf-extractor-transform/1.0.1/spec.json
@@ -5,7 +5,7 @@
   "author": "Cask",
   "org": "Cask Data, Inc.",
   "created": 1496273781,
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "categories": [
     "hydrator-plugin"
   ],

--- a/packages/hydrator-plugin-python-transform/2.2.0/spec.json
+++ b/packages/hydrator-plugin-python-transform/2.2.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1554156215,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[5.1.0-SNAPSHOT, 7.0.0-SNAPSHOT)",
+  "cdapVersion": "[5.1.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-record-splitter-transform/1.6.1/spec.json
+++ b/packages/hydrator-plugin-record-splitter-transform/1.6.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Record Splitter Transform",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496343591,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-redshifttos3-action/1.0.1/spec.json
+++ b/packages/hydrator-plugin-redshifttos3-action/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Redshift to S3 Action",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496343670,
   "categories": [
     "AWS",

--- a/packages/hydrator-plugin-run-transform/1.6.1/spec.json
+++ b/packages/hydrator-plugin-run-transform/1.6.1/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1496343758,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/hydrator-plugin-s3-plugins/1.8.3/spec.json
+++ b/packages/hydrator-plugin-s3-plugins/1.8.3/spec.json
@@ -4,7 +4,7 @@
   "label": "S3 Source and Sink",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1537576199,
   "categories": [
     "AWS",

--- a/packages/hydrator-plugin-s3toredshift-action/1.0.1/spec.json
+++ b/packages/hydrator-plugin-s3toredshift-action/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "S3 to Redshift Action",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496344134,
   "categories": [
     "AWS",

--- a/packages/hydrator-plugin-sftp-plugins/1.3.0/spec.json
+++ b/packages/hydrator-plugin-sftp-plugins/1.3.0/spec.json
@@ -4,7 +4,7 @@
   "label": "SFTP Plugins",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0,6.0.0-SNAPSHOT)",
   "created": 1488417487,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-state-restore/1.0.1/spec.json
+++ b/packages/hydrator-plugin-state-restore/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "State Restore",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496345820,
   "categories": [
     "EDW Offloading",

--- a/packages/hydrator-plugin-to-utf8-action/1.0.1/spec.json
+++ b/packages/hydrator-plugin-to-utf8-action/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "To UTF-8 Action",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496346129,
   "categories": [
     "hydrator-plugin"

--- a/packages/hydrator-plugin-vertica-export/1.0.1-8.0.1/spec.json
+++ b/packages/hydrator-plugin-vertica-export/1.0.1-8.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Vertica Bulk Export",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1488417487,
   "categories": [
     "EDW Offloading", "hydrator-plugin"

--- a/packages/hydrator-plugin-vertica-load/1.0.1-8.0.1/spec.json
+++ b/packages/hydrator-plugin-vertica-load/1.0.1-8.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Vertica Bulk Import",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1488417487,
   "categories": [
     "EDW Offloading", "hydrator-plugin"

--- a/packages/plugin-argument-setter/1.0.0/spec.json
+++ b/packages/plugin-argument-setter/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-azure-decompress-action/1.0.0/spec.json
+++ b/packages/plugin-azure-decompress-action/1.0.0/spec.json
@@ -9,7 +9,7 @@
     "Azure", 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-azure-delete-action/1.0.0/spec.json
+++ b/packages/plugin-azure-delete-action/1.0.0/spec.json
@@ -9,7 +9,7 @@
     "Azure", 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-cdc/2.0.0/spec.json
+++ b/packages/plugin-cdc/2.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1554370173,
   "categories": [ "EDW Offloading", "hydrator-plugin" ],
-  "cdapVersion": "[4.2.0,10.0.0)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-data-profiler/1.0.1/spec.json
+++ b/packages/plugin-data-profiler/1.0.1/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-decompress-action/1.0.0/spec.json
+++ b/packages/plugin-decompress-action/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-dynamic-partitioner/2.0.2/spec.json
+++ b/packages/plugin-dynamic-partitioner/2.0.2/spec.json
@@ -4,7 +4,7 @@
   "label": "Dynamic Partitioner Plugin",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.1, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.1, 6.0.0-SNAPSHOT)",
   "created": 1520619951,
   "categories": [
     "hydrator-plugin"

--- a/packages/plugin-dynamodb/1.0.0/spec.json
+++ b/packages/plugin-dynamodb/1.0.0/spec.json
@@ -9,7 +9,7 @@
     "AWS", 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-file-appender/1.0.0/spec.json
+++ b/packages/plugin-file-appender/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-file-contents-action/1.0.0/spec.json
+++ b/packages/plugin-file-contents-action/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.0.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.0.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-file-merge/1.0.0/spec.json
+++ b/packages/plugin-file-merge/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-kinesis-streaming-source/1.0.0/spec.json
+++ b/packages/plugin-kinesis-streaming-source/1.0.0/spec.json
@@ -9,7 +9,7 @@
     "AWS", 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-kudu/1.1.0/spec.json
+++ b/packages/plugin-kudu/1.1.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1503432491,
   "categories": [ "EDW Offloading", "hydrator-plugin" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-mapr/1.0.0/spec.json
+++ b/packages/plugin-mapr/1.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1510006834,
   "categories": [ "hydrator-plugin" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-mqtt/1.1.0/spec.json
+++ b/packages/plugin-mqtt/1.1.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [
     "hydrator-plugin"
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-multi-table-plugins/1.0.5/spec.json
+++ b/packages/plugin-multi-table-plugins/1.0.5/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-repartitioner/1.0.1/spec.json
+++ b/packages/plugin-repartitioner/1.0.1/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin"
   ],
-  "cdapVersion": "[4.2.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-s3-client-action/1.0.0/spec.json
+++ b/packages/plugin-s3-client-action/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Amazon S3 Client",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.0.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.0.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "created": 1510798748,
   "categories": [
     "AWS",

--- a/packages/plugin-sampling-aggregator/1.0.0/spec.json
+++ b/packages/plugin-sampling-aggregator/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-table-streaming-source/1.0.0/spec.json
+++ b/packages/plugin-table-streaming-source/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/plugin-topn/1.0.1/spec.json
+++ b/packages/plugin-topn/1.0.1/spec.json
@@ -4,7 +4,7 @@
   "label": "Top N",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1496683048,
   "categories": [
     "EDW Offloading",

--- a/packages/plugin-trash-sink/1.0.0/spec.json
+++ b/packages/plugin-trash-sink/1.0.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Trash Sink Plugin",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.1.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.1.0,6.0.0-SNAPSHOT)",
   "created": 1487643280,
   "categories": [
     "hydrator-plugin"

--- a/packages/plugin-whole-file-ingest/1.0.0/spec.json
+++ b/packages/plugin-whole-file-ingest/1.0.0/spec.json
@@ -8,7 +8,7 @@
   "categories": [ 
     "hydrator-plugin" 
   ],
-  "cdapVersion": "[4.3.0-SNAPSHOT,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",

--- a/packages/solution-bulk-data-transfer/1.2.0/spec.json
+++ b/packages/solution-bulk-data-transfer/1.2.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Bulk Data Transfer",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496270593,
   "categories": [
     "usecase"
@@ -60,7 +60,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.2.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/solution-cdc-oracle-to-kudu/1.0.0/spec.json
+++ b/packages/solution-cdc-oracle-to-kudu/1.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1490838885,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.2.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -48,7 +48,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-cdc-oracle-to-kudu/2.0.0/spec.json
+++ b/packages/solution-cdc-oracle-to-kudu/2.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1554370173,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.2.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -48,7 +48,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-cdc-sqlserver-to-hbase/1.0.0/spec.json
+++ b/packages/solution-cdc-sqlserver-to-hbase/1.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1490838885,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.2.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -48,7 +48,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-cdc-sqlserver-to-hbase/2.0.0/spec.json
+++ b/packages/solution-cdc-sqlserver-to-hbase/2.0.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1554370173,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.2.0,10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.2.0,6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -48,7 +48,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.2.0, 10.0.0-SNAPSHOT)"
+            "version": "[4.2.0, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-incremental-data-ingest/1.2.0/spec.json
+++ b/packages/solution-incremental-data-ingest/1.2.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1496271953,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -105,7 +105,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-kudu-to-netezza-analysis/1.2.0/spec.json
+++ b/packages/solution-kudu-to-netezza-analysis/1.2.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1503432491,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -79,7 +79,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-netezza-to-kudu-fulldump/1.2.0/spec.json
+++ b/packages/solution-netezza-to-kudu-fulldump/1.2.0/spec.json
@@ -6,7 +6,7 @@
   "org": "Cask Data, Inc.",
   "created": 1503432491,
   "categories": [ "usecase", "EDW Offloading" ],
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "actions": [
     {
       "type": "one_step_deploy_plugin",
@@ -79,7 +79,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-pipeline",
-            "version": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           }
         },
         {

--- a/packages/solution-realtime-log-ingestion/1.3.0/spec.json
+++ b/packages/solution-realtime-log-ingestion/1.3.0/spec.json
@@ -4,7 +4,7 @@
   "label": "Real-time Log Analytics",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496281134,
   "categories": [
     "usecase"
@@ -64,7 +64,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },

--- a/packages/solution-rss-feed-processing/1.3.0/spec.json
+++ b/packages/solution-rss-feed-processing/1.3.0/spec.json
@@ -4,7 +4,7 @@
   "label": "HTTP Source Data Ingestion",
   "author": "Cask",
   "org": "Cask Data, Inc.",
-  "cdapVersion": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)",
+  "cdapVersion": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)",
   "created": 1496281517,
   "categories": [
     "usecase"
@@ -50,7 +50,7 @@
           "value": {
             "scope": "system",
             "name": "cdap-data-streams",
-            "version": "[4.3.0-SNAPSHOT, 10.0.0-SNAPSHOT)"
+            "version": "[4.3.0-SNAPSHOT, 6.0.0-SNAPSHOT)"
           },
           "canModify": false
         },


### PR DESCRIPTION
Modify all spec.json to set 6.0.0-SNAPSHOT as the upper bound, unless the upper bound is 4.x or 5.x.

This change will effectively hide everything in market from CDAP versions 6.x+